### PR TITLE
authors can now view user profile details

### DIFF
--- a/src/components/nav/AuthorNavBar.js
+++ b/src/components/nav/AuthorNavBar.js
@@ -36,7 +36,8 @@ export const AuthorNavBar = ({ token, setToken }) => {
                   <Link to="/my-posts" className="navbar-item">My Posts</Link>
                   <Link to="/tags" className="navbar-item">Tag Management</Link>
                   <Link to="/posts/create" className="navbar-item">New Post</Link>    
-                  <Link to="/categories" className="navbar-item">Category Management</Link>      
+                  <Link to="/categories" className="navbar-item">Category Management</Link> 
+                  <Link to="/users" className="navbar-item">User Profiles</Link>      
               </>
               :
               ""

--- a/src/components/users/AuthorUserDetails.js
+++ b/src/components/users/AuthorUserDetails.js
@@ -1,0 +1,83 @@
+import { useEffect, useState } from "react"
+import { Link, useParams } from "react-router-dom"
+import { getPostById } from "../../managers/PostManager"
+import { FaUserCircle } from 'react-icons/fa'
+import { getDetailedUser } from "../../managers/UserManager"
+
+export const AuthorUserDetails = () => {
+  const [user, setUserDetails ] = useState({})
+  const [formattedDate, setFormattedDate] = useState("")
+  const { userId } = useParams()
+
+  useEffect(() => {
+    getDetailedUser(userId).then(setUserDetails)
+  }, [userId])
+
+//   useEffect(
+//     () => {
+//         if (user?.user?.date_joined) {
+//             const myDate = user.user.date_joined
+//             const newDate = myDate.toLocaleDateString('en-US')
+//             setFormattedDate(newDate)
+//         }
+//     },
+//     [user]
+//   )
+
+  return <section className="section">
+    <div className="card">
+      <header className="card-header is-justify-content-center">
+        <h2 className="title is-size-3 p-3 ">
+          {user?.user?.first_name} {user?.user?.last_name}
+        </h2>
+      </header>
+      <div className="card-image">
+        <figure className="image">
+            {
+                (user.profile_image_url)
+                ? <img src={user?.profile_image_url} alt={user?.user?.username} />
+                : <img src="https://cdn.media.amplience.net/i/partycity/176114?$large$" alt="default image" />
+            }
+        </figure>
+      </div>
+      <div className="card-content">
+        <div className="media">
+          <div className="media-left">
+            <span className="icon is-large">
+              <FaUserCircle size={'3rem'} />
+            </span>
+          </div>
+          <div className="media-content">
+            
+            <p className="subtitle is-6">Username: {user.user?.username}</p>
+            <p className="subtitle is-6">email{user?.user?.email}</p>
+            
+          </div>
+        </div>
+
+        <div className="content">
+          Bio: {user?.bio}
+          <hr />
+        </div>
+
+        <div className="content">
+        <time>Date Joined: {new Date(user?.user?.date_joined).toLocaleDateString('en-US')}</time>
+          <hr />
+        </div>
+
+        
+
+        <div className="content">
+            {
+                (user?.user?.is_staff)
+                ? <p>User Type: Admin</p>
+                : <p>User Type: Author</p>
+            }
+        </div>
+      </div>
+      <footer className="card-footer">
+        
+      </footer>
+    </div>
+  </section>
+}

--- a/src/components/users/AuthorUserList.js
+++ b/src/components/users/AuthorUserList.js
@@ -1,0 +1,37 @@
+import { useState, useEffect } from "react"
+import { Link } from "react-router-dom"
+import { getAllActiveUsers } from "../../managers/UserManager"
+
+export const AuthorUserList = () => {
+    const [users, setUsers] = useState([])
+
+    useEffect(
+        () => {
+            getAllActiveUsers().then(setUsers)
+        },
+        []
+    )
+
+    return <section className="section">
+        <div className="column">
+            <table className="table is-fullwidth">
+                <thead>
+                    <tr>
+                        <th>Users</th>
+                        <th>Full Name</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {
+                        users.map(user => (
+                            <tr key={user.id}>
+                                <td><Link to={`/users/${user.id}`}>{user.user.username}</Link></td>
+                                <td>{user.user.first_name} {user.user.last_name}</td>
+                            </tr>
+                        ))
+                    }
+                </tbody>
+            </table>
+        </div>
+    </section>
+}

--- a/src/managers/UserManager.js
+++ b/src/managers/UserManager.js
@@ -6,3 +6,21 @@ export const getAllUsers = () => {
     })
       .then(res => res.json())
   }
+
+  export const getAllActiveUsers = () => {
+    return fetch("http://localhost:8000/users/active", {
+      headers: {
+        'Authorization': `Token ${localStorage.getItem('auth_token')}`
+      }
+    })
+      .then(res => res.json())
+  }
+
+export const getDetailedUser = (userId) => {
+  return fetch(`http://localhost:8000/users/${userId}`, {
+      headers: {
+        'Authorization': `Token ${localStorage.getItem('auth_token')}`
+      }
+    })
+      .then(res => res.json())
+}

--- a/src/views/AuthorViews.js
+++ b/src/views/AuthorViews.js
@@ -12,6 +12,8 @@ import { EditPost } from "../components/posts/EditPost"
 import { CommentForm } from "../components/comments/CommentForm"
 import { CommentsList } from "../components/comments/CommentList"
 import { CommentEdit } from "../components/comments/CommentEdit"
+import { AuthorUserList } from "../components/users/AuthorUserList"
+import { AuthorUserDetails } from "../components/users/AuthorUserDetails"
 
 
 
@@ -33,7 +35,8 @@ export const AuthorViews = ({ token, setToken, setUserId, userId, setStaffBool }
       <Route path="/posts/:postId" element={<PostDetails userId={userId} />} />
       <Route path="/posts/:postId/add-comment" element={<CommentForm />} />
       <Route path="/posts/:commentId/edit-comment" element={<CommentEdit />} />
-
+      <Route path="/users" element={<AuthorUserList />} />
+      <Route path="/users/:userId" element={<AuthorUserDetails />} />
     </Route>
   </Routes>
 }


### PR DESCRIPTION
# Description

If you are logged in as an author, you should be able to go to a list of all active users. You can click on an authors username and it'll show their detailed information.

Fixes # 21

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

1. log in as an author
2. go to user profiles
3. click on a username
4. see if full name, avatar image (should default to a clown if user doesn't have one), username, email, join date, and user type all display

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
