### PR TITLE
Admins can activate and deactivate users

### DIFF
--- a/src/components/users/UserList.js
+++ b/src/components/users/UserList.js
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react"
 import { Link, useNavigate } from "react-router-dom"
-import { getAllUsers } from "../../managers/UserManager"
+import { getAllActiveUsers, getAllInactiveUsers, updateUserActiveStatus } from "../../managers/UserManager"
 
 export const UserList = () => {
 
@@ -8,12 +8,48 @@ export const UserList = () => {
 
     useEffect(
         () => {
-            getAllUsers().then(setUsers)
+            showActiveUsers()
         },
         []
     )
 
+    const showActiveUsers = () => {
+        getAllActiveUsers().then(setUsers)
+    }
+
+    const showInactiveUsers = () => {
+        getAllInactiveUsers().then(setUsers)
+    }
+
+    const confirmDeactivate = (userId) => {
+        if (window.confirm("Do you want to deactivate this user?")) {
+            handleDeactivate(userId)
+        }
+    }
+
+    const handleDeactivate = (userId) => {
+        updateUserActiveStatus(userId).then(
+            showActiveUsers()
+        )
+    }
+
+    const confirmActivate = (userId) => {
+        if (window.confirm("Do you want to reactivate this user?")) {
+            handleActivate(userId)
+        }
+    }
+
+    const handleActivate = (userId) => {
+        updateUserActiveStatus(userId).then(
+            showInactiveUsers()
+        )
+    }
+
     return <section className="section">
+        <div>
+            <button className="button is-info" onClick={() => { showActiveUsers() }}>View Active Users</button>
+            <button className="button is-warning" onClick={() => { showInactiveUsers() }}>View Inactive Users</button>
+        </div>
         <div className="column">
             <table className="table is-fullwidth">
                 <thead>
@@ -21,6 +57,7 @@ export const UserList = () => {
                         <th>Users</th>
                         <th>Full Name</th>
                         <th>User Type</th>
+                        <th>Update User Status</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -34,6 +71,13 @@ export const UserList = () => {
                                         (user.user.is_staff)
                                             ? <>Admin</>
                                             : <>Author</>
+                                    }
+                                </td>
+                                <td>
+                                    {
+                                        (user.user.is_active)
+                                            ? <button className="button is-danger" onClick={() => { confirmDeactivate(user.id) }}>Deactivate</button>
+                                            : <button className="button is-warning" onClick={() => { confirmActivate(user.id) }}>Activate</button>
                                     }
                                 </td>
                             </tr>

--- a/src/managers/UserManager.js
+++ b/src/managers/UserManager.js
@@ -16,6 +16,15 @@ export const getAllUsers = () => {
       .then(res => res.json())
   }
 
+  export const getAllInactiveUsers = () => {
+    return fetch("http://localhost:8000/users/inactive", {
+      headers: {
+        'Authorization': `Token ${localStorage.getItem('auth_token')}`
+      }
+    })
+      .then(res => res.json())
+  }
+
 export const getDetailedUser = (userId) => {
   return fetch(`http://localhost:8000/users/${userId}`, {
       headers: {
@@ -23,4 +32,16 @@ export const getDetailedUser = (userId) => {
       }
     })
       .then(res => res.json())
+}
+
+
+
+export const updateUserActiveStatus = (userId) => {
+  return fetch(`http://localhost:8000/users/${userId}/active_status`, {
+      method: 'PUT',
+      headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Token ${localStorage.getItem('auth_token')}`
+      }
+  })
 }


### PR DESCRIPTION
# Description

Admins can now activate and deactivate users on the User Profile list. User Profile list will show "view active users" and "view inactive users" buttons at top. Admin can update user status and inactive / active lists will respond accordingly.

Fixes # 19 & 20

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

1. make sure you have new server main from this pr: https://github.com/nss-day-cohort-56/rare-server-team-1-2/pull/18
2. log in as an admin
3. go to user profiles
4. try do deactivate a user. That user should now appear under the "view deactivated users" list.
5. go to deactivated user list. Try to reactivate that user.
6. Go to activated user list. Reactivated user should appear there. 

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings